### PR TITLE
RDS 101 - Input Processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,13 @@ crashlytics-build.properties
 # If the source bank files are kept outside of the StreamingAssets folder then these can be ignored.
 # Log files can be ignored.
 fmod_editor.log
+
+##### PROJECT RIDERS #####
+
+# Ignore Config folder
+/[Aa]ssets/[Cc]onfig.meta
+/[Aa]ssets/[Cc]onfig/
+
+# Ignore Logs folder
+/[Aa]ssets/[Ll]ogs.meta
+/[Aa]ssets/[Ll]ogs/

--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -750,6 +750,34 @@
                     "isPartOfComposite": false
                 }
             ]
+        },
+        {
+            "name": "Debug",
+            "id": "360a51ba-7322-466c-83ec-7a8ece887667",
+            "actions": [
+                {
+                    "name": "Save Input History",
+                    "type": "Button",
+                    "id": "05284434-e698-4da0-a286-825bb11da0a7",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "23e390af-9110-43e8-8de6-aee06ca632fd",
+                    "path": "<Keyboard>/p",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Save Input History",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
         }
     ],
     "controlSchemes": [

--- a/Assets/Scenes/TestPlayground_Skate.unity
+++ b/Assets/Scenes/TestPlayground_Skate.unity
@@ -1229,6 +1229,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 962424340}
   m_CullTransparentMesh: 1
+--- !u!1 &1200380539
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1200380541}
+  - component: {fileID: 1200380540}
+  m_Layer: 0
+  m_Name: DEBUG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1200380540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1200380539}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d583aef73cde1994284f05da96c2498b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  allowSavingInputHistoryToFile: 0
+--- !u!4 &1200380541
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1200380539}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.380529, y: -3.0745664, z: -3.2938032}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1220690909
 GameObject:
   m_ObjectHideFlags: 0
@@ -2057,3 +2102,4 @@ SceneRoots:
   - {fileID: 701140539}
   - {fileID: 2072464519}
   - {fileID: 1923485782}
+  - {fileID: 1200380541}

--- a/Assets/Scenes/TestPlayground_Skate.unity
+++ b/Assets/Scenes/TestPlayground_Skate.unity
@@ -119,6 +119,35 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &15337380 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2072811018097086297, guid: 23807211aeadb98419af99c5f1754af3, type: 3}
+  m_PrefabInstance: {fileID: 1791229616780291932}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &15337384 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4448864653755112223, guid: 23807211aeadb98419af99c5f1754af3, type: 3}
+  m_PrefabInstance: {fileID: 1791229616780291932}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 15337380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5256c658527fb8f439d3da0e44dd8834, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &15337388
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 15337380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65408980f2acb854bb753bc9c42be385, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inputSource: {fileID: 15337384}
 --- !u!1 &48857180
 GameObject:
   m_ObjectHideFlags: 0
@@ -2007,7 +2036,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2072811018097086297, guid: 23807211aeadb98419af99c5f1754af3, type: 3}
+      insertIndex: 4
+      addedObject: {fileID: 15337388}
   m_SourcePrefab: {fileID: 100100000, guid: 23807211aeadb98419af99c5f1754af3, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:

--- a/Assets/Scripts/DebugFlags.cs
+++ b/Assets/Scripts/DebugFlags.cs
@@ -16,6 +16,8 @@ public class DebugFlags : MonoBehaviour
         // Then in other scripts, you can access the state with DebugFlags.Instance.Name
     }
 
+    public string DebugInputMapName = "Debug";
+
     [Header("Debug Toggles")]
     public bool allowSavingInputHistoryToFile = false;
 

--- a/Assets/Scripts/DebugFlags.cs
+++ b/Assets/Scripts/DebugFlags.cs
@@ -1,0 +1,105 @@
+using System.IO;
+using System.Reflection;
+using UnityEngine;
+
+public class DebugFlags : MonoBehaviour
+{
+    public static DebugFlags Instance { get; private set; }
+
+    // This is needed to be able to save/load from a JSON config file
+    [System.Serializable]
+    private class DebugFlagData
+    {
+        public bool allowSavingInputHistoryToFile = false;
+
+        // Add any more debug toggles here. AND UNDER THE HEADER BELOW.
+        // Then in other scripts, you can access the state with DebugFlags.Instance.Name
+    }
+
+    [Header("Debug Toggles")]
+    public bool allowSavingInputHistoryToFile = false;
+
+    private string ConfigPath
+    {
+        get
+        {
+            string configDir = Path.Combine(Application.dataPath, "Config");
+            if (!Directory.Exists(configDir)) Directory.CreateDirectory(configDir);
+            return Path.Combine(configDir, "debug_flags.json");
+        }
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        LoadFromFile();
+    }
+
+    private void OnDisable()
+    {
+        SaveToFile();
+    }
+
+    private void Start()
+    {
+        Debug.Log("[DebugFlags] Current Debug Toggles:");
+        PrintCurrentToggleValues();
+    }
+
+    private void PrintCurrentToggleValues()
+    {
+        // Print current values of the toggles
+        foreach (var field in GetType().GetFields(BindingFlags.Instance | BindingFlags.Public))
+        {
+            Debug.Log($"{field.Name}: {field.GetValue(this)}");
+        }
+    }
+
+    public void SaveToFile()
+    {
+        var data = new DebugFlagData();
+
+        foreach (var field in typeof(DebugFlagData).GetFields(BindingFlags.Instance | BindingFlags.Public))
+        {
+            var thisField = GetType().GetField(field.Name, BindingFlags.Instance | BindingFlags.Public);
+            if (thisField != null)
+            {
+                field.SetValue(data, thisField.GetValue(this));
+            }
+        }
+
+        string json = JsonUtility.ToJson(data, true);
+        File.WriteAllText(ConfigPath, json);
+        Debug.Log($"[DebugFlags] Saved to: {ConfigPath}");
+    }
+
+    public void LoadFromFile()
+    {
+        if (!File.Exists(ConfigPath))
+        {
+            Debug.Log("[DebugFlags] No config found. Using default toggle values.");
+            return;
+        }
+
+        string json = File.ReadAllText(ConfigPath);
+        var data = JsonUtility.FromJson<DebugFlagData>(json);
+
+        foreach (var field in typeof(DebugFlagData).GetFields(BindingFlags.Instance | BindingFlags.Public))
+        {
+            var thisField = GetType().GetField(field.Name, BindingFlags.Instance | BindingFlags.Public);
+            if (thisField != null)
+            {
+                thisField.SetValue(this, field.GetValue(data));
+            }
+        }
+
+        Debug.Log($"[DebugFlags] Loaded toggles from: {ConfigPath}");
+    }
+}

--- a/Assets/Scripts/DebugFlags.cs.meta
+++ b/Assets/Scripts/DebugFlags.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d583aef73cde1994284f05da96c2498b

--- a/Assets/Scripts/VehicleSystems/Inputs/BaseInput.cs
+++ b/Assets/Scripts/VehicleSystems/Inputs/BaseInput.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 
 // All the relevant input data for the "actor" in the world
+[System.Serializable]
 public struct ActorInputData
 {
     public float Accelerate;

--- a/Assets/Scripts/VehicleSystems/Inputs/InputFrameRecord.cs
+++ b/Assets/Scripts/VehicleSystems/Inputs/InputFrameRecord.cs
@@ -1,0 +1,12 @@
+[System.Serializable]
+public struct InputFrameRecord
+{
+    public int Frame;
+    public ActorInputData Input;
+
+    public InputFrameRecord(int frame, ActorInputData input)
+    {
+        Frame = frame;
+        Input = input;
+    }
+}

--- a/Assets/Scripts/VehicleSystems/Inputs/InputFrameRecord.cs.meta
+++ b/Assets/Scripts/VehicleSystems/Inputs/InputFrameRecord.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c8a7a750e8054e4e9bc3560fe451797

--- a/Assets/Scripts/VehicleSystems/Inputs/InputProcessor.cs
+++ b/Assets/Scripts/VehicleSystems/Inputs/InputProcessor.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 // For JSON serialisation
 [System.Serializable]
@@ -16,6 +17,15 @@ public class InputProcessor : MonoBehaviour
 
     public List<InputFrameRecord> inputHistory { get; private set; } = new();
 
+    private InputActionAsset playerInput;
+    private InputActionMap inputMap;
+
+    void Awake()
+    {
+        playerInput = GetComponent<UnityEngine.InputSystem.PlayerInput>().actions;
+        inputMap = playerInput.FindActionMap(DebugFlags.Instance.DebugInputMapName);
+    }
+
     void Update()
     {
         ActorInputData currentInput = inputSource.GrabCurrentFrameInputs();
@@ -26,10 +36,13 @@ public class InputProcessor : MonoBehaviour
         inputHistory.Add(record);
 
         // DEBUG - EXPORT TO CSV AND JSON
-        if (Input.GetKeyDown(KeyCode.P))
+        if (DebugFlags.Instance.allowSavingInputHistoryToFile == true)
         {
-            SaveHistoryAsCsv();
-            SaveHistoryAsJson();
+            if (inputMap.FindAction("Save Input History").triggered)
+            {
+                SaveHistoryAsCsv();
+                SaveHistoryAsJson();
+            }
         }
     }
 

--- a/Assets/Scripts/VehicleSystems/Inputs/InputProcessor.cs
+++ b/Assets/Scripts/VehicleSystems/Inputs/InputProcessor.cs
@@ -33,6 +33,16 @@ public class InputProcessor : MonoBehaviour
         }
     }
 
+    private string LogsPath
+    {
+        get
+        {
+            string logsDir = Path.Combine(Application.dataPath, "Logs");
+            if (!Directory.Exists(logsDir)) Directory.CreateDirectory(logsDir);
+            return logsDir;
+        }
+    }
+
     public void ClearHistory()
     {
         inputHistory.Clear();
@@ -46,7 +56,7 @@ public class InputProcessor : MonoBehaviour
     // DEBUG
     public void SaveHistoryAsCsv()
     {
-        string path = Path.Combine(Application.dataPath, "InputHistory.csv");
+        string path = Path.Combine(LogsPath, "InputHistory.csv");
         StringBuilder csv = new StringBuilder();
 
         csv.AppendLine("Frame,Accelerate,Brake,TurnInput,Jump,JumpHoldDuration,StuntA,StuntB,StuntC,Drift,BoostRam");
@@ -74,7 +84,7 @@ public class InputProcessor : MonoBehaviour
     // DEBUG
     public void SaveHistoryAsJson()
     {
-        string path = Path.Combine(Application.dataPath, "InputHistory.json");
+        string path = Path.Combine(LogsPath, "InputHistory.json");
 
         InputHistoryData historyData = new InputHistoryData
         {

--- a/Assets/Scripts/VehicleSystems/Inputs/InputProcessor.cs
+++ b/Assets/Scripts/VehicleSystems/Inputs/InputProcessor.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using UnityEngine;
+
+// For JSON serialisation
+[System.Serializable]
+public class InputHistoryData
+{
+    public List<InputFrameRecord> inputHistory = new();
+}
+
+public class InputProcessor : MonoBehaviour
+{
+    public BaseInput inputSource;
+
+    public List<InputFrameRecord> inputHistory { get; private set; } = new();
+
+    void Update()
+    {
+        ActorInputData currentInput = inputSource.GrabCurrentFrameInputs();
+        int currentFrame = Time.frameCount;
+
+        var record = new InputFrameRecord(currentFrame, currentInput);
+
+        inputHistory.Add(record);
+
+        // DEBUG - EXPORT TO CSV AND JSON
+        if (Input.GetKeyDown(KeyCode.P))
+        {
+            SaveHistoryAsCsv();
+            SaveHistoryAsJson();
+        }
+    }
+
+    public void ClearHistory()
+    {
+        inputHistory.Clear();
+    }
+
+    public InputFrameRecord GetFrame(int frame)
+    {
+        return inputHistory.Find(record => record.Frame == frame);
+    }
+
+    // DEBUG
+    public void SaveHistoryAsCsv()
+    {
+        string path = Path.Combine(Application.dataPath, "InputHistory.csv");
+        StringBuilder csv = new StringBuilder();
+
+        csv.AppendLine("Frame,Accelerate,Brake,TurnInput,Jump,JumpHoldDuration,StuntA,StuntB,StuntC,Drift,BoostRam");
+
+        foreach (var record in inputHistory)
+        {
+            var input = record.Input;
+            csv.AppendLine($"{record.Frame}," +
+                           $"{input.Accelerate}," +
+                           $"{input.Brake}," +
+                           $"{input.TurnInput}," +
+                           $"{input.Jump}," +
+                           $"{input.JumpHoldDuration}," +
+                           $"{input.StuntA}," +
+                           $"{input.StuntB}," +
+                           $"{input.StuntC}," +
+                           $"{input.Drift}," +
+                           $"{input.BoostRam}");
+        }
+
+        File.WriteAllText(path, csv.ToString());
+        Debug.Log($"Input history saved to {path}");
+    }
+
+    // DEBUG
+    public void SaveHistoryAsJson()
+    {
+        string path = Path.Combine(Application.dataPath, "InputHistory.json");
+
+        InputHistoryData historyData = new InputHistoryData
+        {
+            inputHistory = inputHistory
+        };
+
+        string json = JsonUtility.ToJson(historyData, true);
+
+        File.WriteAllText(path, json);
+        Debug.Log($"Input history saved to {path}");
+    }
+
+}

--- a/Assets/Scripts/VehicleSystems/Inputs/InputProcessor.cs.meta
+++ b/Assets/Scripts/VehicleSystems/Inputs/InputProcessor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 65408980f2acb854bb753bc9c42be385


### PR DESCRIPTION
This PR does the following things:

- Adds a new struct: **InputFrameRecord**
  - This stores the ActorInputData and frame number
  - One record is for each frame
 
- Adds a new script: **InputProcessor**
  - Script gets added on to the player, and takes in the player's Player Input Script
  - Every frame, make a new InputFrameRecord, and store into a list
  - When user presses P, save history as both CSV and JSON (for debugging purposes)

- Made ActorInputData Serializable for JSON