### PR TITLE
split inputs into update

### DIFF
--- a/Assets/Scripts/VehicleSystems/BaseVehicle.cs
+++ b/Assets/Scripts/VehicleSystems/BaseVehicle.cs
@@ -283,11 +283,14 @@ public class BaseVehicle : MonoBehaviour
     //    m_DriftSparkInstances.Add((wheel, horizontalOffset, -rotation, spark));
     //}
 
-    //make virtual?
-    void Update()
+    private void Update()
     {
         GatherInputs();
+    }
 
+    //make virtual?
+    void FixedUpdate()
+    {
         // maybe later
         // apply our powerups to create our finalStats
         TickPowerups();
@@ -315,6 +318,8 @@ public class BaseVehicle : MonoBehaviour
         float wheelCount = m_VisualWheels.Count;
         GroundPercent = (float)groundedCount / wheelCount;
         AirPercent = 1 - GroundPercent;
+
+        Debug.Log("GroundPercent: " + GroundPercent);
 
         // apply vehicle physics
         if (m_CanMove)

--- a/Assets/Scripts/VehicleSystems/Inputs/PlayerInput.cs
+++ b/Assets/Scripts/VehicleSystems/Inputs/PlayerInput.cs
@@ -59,7 +59,7 @@ public class PlayerInput : BaseInput
                 inputValues.Add(action.name, action.ReadValue<float>());
             }
 
-            Debug.Log(inputValues["Jump"]);
+            Debug.Log("Jump value: " + inputValues["Jump"]);
         }
 
         // Convert to actor input data


### PR DESCRIPTION
- create Update() method that only contains GatherInputs()
- rename old Update() method to FixedUpdate()

does not currently fix the problem of jump inputs not being read but should be a start to a fix, hopefully?