### PR TITLE
RDS 98 - Tricks Input Register

### DIFF
--- a/Assets/Scripts/RidersGame/StuntSystem/StuntDatabase.cs
+++ b/Assets/Scripts/RidersGame/StuntSystem/StuntDatabase.cs
@@ -7,7 +7,6 @@ namespace RidersRuntime.StuntSystem
     public class StuntDatabase
     {
         public List<Stunt> stunts = new List<Stunt>();
-        public int frameDelayMax = 15;
 
         public void PopulateStunts()
         {
@@ -27,42 +26,34 @@ namespace RidersRuntime.StuntSystem
             // Add more stunts as needed
         }
 
-        public Stunt QueryStuntByFrames(StuntType stuntType, List<FrameKeyData> data)
+        public Stunt QueryStuntByTime(StuntType stuntType, List<TimedInput> inputs)
         {
-            // dogshit o(n!))
-            // Copy the whole list over that match the stunt type
-            List<Stunt> currentValidStunt = stunts.FindAll(stunt => stunt.type == stuntType);
-            List<string> keys = GetLastPressedKeys(data.Select(frame => frame.inputs).ToList());
+            List<Stunt> validStunts = stunts.FindAll(s => s.type == stuntType);
 
-            foreach (var stunt in stunts)
+            foreach (var stunt in validStunts)
             {
-                int comboIndex = 0;
-                for (int i = 0; i < data.Count; i++)
+                int comboIdx = 0;
+                float startTime = -1f;
+
+                foreach (var input in inputs)
                 {
-                    // Check if the current frame contains the next combo key
-                    if (comboIndex < stunt.comboKeys.Length && data[i].inputs.Contains(stunt.comboKeys[comboIndex]))
+                    if (input.key == stunt.comboKeys[comboIdx])
                     {
-                        comboIndex++;
-                    }
+                        if (comboIdx == 0) startTime = input.time;
+                        comboIdx++;
 
-                    if (comboIndex == stunt.comboKeys.Length)
-                    {
-                        // From here we then check the frame count
-                        // Check if the frame count is within the allowed range
-                        int frameCount = 0;
-                        int startingFrame = i - stunt.comboKeys.Length + 1;
-                        for (int j = startingFrame; j < data.Count; j++)
+                        if (comboIdx == stunt.comboKeys.Length)
                         {
-                            frameCount += data[j].frameCount;
+                            if (input.time - startTime <= Values.timeWindowMax)
+                                return stunt;
+                            else
+                                break;
                         }
-
-                        if (frameCount <= frameDelayMax) return stunt;
-                        else comboIndex = 0;
                     }
                 }
             }
 
-            return Stunt.None; // No matching stunt combo found
+            return Stunt.None;
         }
 
         public List<string> GetLastPressedKeys(List<List<string>> keys)

--- a/Assets/Scripts/RidersGame/StuntSystem/StuntPeripheralInputHandler.cs
+++ b/Assets/Scripts/RidersGame/StuntSystem/StuntPeripheralInputHandler.cs
@@ -13,16 +13,15 @@ namespace RidersRuntime.StuntSystem
         StuntSystem stuntSystem;
         IInput playerPeripheralInput;
         public bool isInRecordingMode = false;
-        List<FrameKeyData> recordedKeys = new();
+        private Queue<TimedInput> inputBuffer = new();
+        private List<string> previousFrameKeys = new();
 
         StuntType currentStunt = StuntType.None;
-        int pollFrameHoldCounter = 0;
 
         void Start()
         {
             playerPeripheralInput = GetComponent<PlayerInput>();
             stuntSystem = GetComponent<StuntSystem>();
-            Application.targetFrameRate = 60;
         }
 
         public void Initialize()
@@ -32,29 +31,44 @@ namespace RidersRuntime.StuntSystem
 
         void Update()
         {
-            if (isInRecordingMode)
-            {
-                ActorInputData currentFrameData = playerPeripheralInput.GrabCurrentFrameInputs();
-                // Interpret this and record it down
+            if (!isInRecordingMode) return;
 
-                // If any has been pressed we can handle all cases 
-                List<string> lastPressedKeys = RecordKeyFrames(currentFrameData, out bool isNew);
-                List<string> stuntIntersect = lastPressedKeys.Intersect(StuntButtonNamesShort.AllStuntButtons).ToList();
-                if (stuntIntersect.Count() > 0 && isNew)
-                {
-                    HandleStuntKeyPress(stuntIntersect[0]);
-                }
+            // Prune old inputs
+            while (inputBuffer.Count > 0 && Time.time - inputBuffer.Peek().time > Values.timeWindowMax)
+                inputBuffer.Dequeue();
+
+            // Get new inputs
+            var current = playerPeripheralInput.GrabCurrentFrameInputs();
+            var keys = GetCurrentKeys(current);
+            foreach (var key in keys)
+                inputBuffer.Enqueue(new TimedInput { key = key, time = Time.time });
+
+            List<string> newKeys = keys.Except(previousFrameKeys).ToList();
+            var newStuntKey = newKeys.FirstOrDefault(k => StuntButtonNamesShort.AllStuntButtons.Contains(k));
+            if (newStuntKey != null)
+            {
+                HandleStuntKeyPress(newStuntKey);
             }
+            previousFrameKeys = keys;
+
         }
 
         void HandleStuntKeyPress(string key)
         {
             currentStunt = Values.stuntBindings[key];
-            // Build print out the actions for the last 10 actions
-            List<FrameKeyData> keys = recordedKeys.Skip(Mathf.Max(0, recordedKeys.Count - 10)).ToList();
-
-            stuntSystem.OnStuntRequestWithFrameData(keys, currentStunt);
+            stuntSystem.OnStuntRequestTimed(new List<TimedInput>(inputBuffer), currentStunt);
             currentStunt = StuntType.None;
+        }
+
+
+        List<string> GetCurrentKeys(ActorInputData input)
+        {
+            float horizontal = input.TurnInput;
+            float vertical = input.Accelerate > 0 ? input.Accelerate : -1 * input.Brake;
+            int dir = ConvertVector2To8WayDirection(new Vector2(horizontal, vertical));
+            var keys = input.KeysThatAreNonZeroExceptAnalog();
+            keys.Add(dir.ToString());
+            return keys;
         }
 
         int ConvertVector2To8WayDirection(Vector2 input)
@@ -75,84 +89,6 @@ namespace RidersRuntime.StuntSystem
             if (input.y < deadzone) return 2; // Down
 
             return -1; // No valid direction
-        }
-
-        List<string> RecordKeyFrames(ActorInputData input, out bool isNew)
-        {
-            isNew = false;
-            // 1. Convert from 3 var input to 1 var 8 way input
-            // Need to reimplement this - adapter to 8 way
-            float horizontal = input.TurnInput;
-            float vertical = input.Accelerate;
-            vertical = vertical > 0 ? vertical : -1 * input.Brake;
-
-            int direction = ConvertVector2To8WayDirection(new(horizontal, vertical));
-
-            // 2. Get all positive inputs
-            List<string> currentFrameKeys = input.KeysThatAreNonZeroExceptAnalog();
-            currentFrameKeys.Add(direction.ToString());
-
-            // Grab information about the previous frame
-            List<string> previousFrameKeys = recordedKeys.Count > 0 ? recordedKeys.Last().inputs : new List<string>();
-            // Check if the current frame keys are different from the previous frame keys
-            if (currentFrameKeys.SequenceEqual(previousFrameKeys))
-            {
-                pollFrameHoldCounter++;
-                // Replace the last entry in the list with the current frame keys
-                recordedKeys[^1] = new FrameKeyData
-                {
-                    frameCount = pollFrameHoldCounter,
-                    inputs = currentFrameKeys
-                };
-            }
-            else
-            {
-                pollFrameHoldCounter = 1;
-                isNew = true;
-                recordedKeys.Add(new FrameKeyData
-                {
-                    frameCount = 1,
-                    inputs = currentFrameKeys
-                });
-            }
-
-            return currentFrameKeys;
-        }
-
-
-        // Function to get the last pressed keys from a list of lists of keystrokes
-        public static List<string> GetLastPressedKeys(List<List<string>> keys)
-        {
-            List<string> lastPressedKeys = new();
-            List<string> previous = new();
-
-            foreach (var keystrokes in keys)
-            {
-                var newKeys = keystrokes.Except(previous).ToList();
-                if (newKeys.Count > 0) lastPressedKeys.Add(newKeys[0]);
-
-                previous = keystrokes;
-            }
-
-            return lastPressedKeys;
-        }
-
-        public static void ShowPressedKeys(List<FrameKeyData> keys)
-        {
-            foreach (var key in keys)
-            {
-                Debug.Log($"Frame: {key.frameCount}, Keys: {string.Join(", ", key.inputs)}");
-            }
-        }
-        public static void ShowSingleLineOutput(List<FrameKeyData> keys)
-        {
-            List<List<string>> keyInputs = new();
-            foreach (var frameData in keys)
-            {
-                keyInputs.Add(frameData.inputs);
-            }
-            List<string> lastPressedKeys = GetLastPressedKeys(keyInputs);
-            Debug.Log($"Last pressed keys: {string.Join(", ", lastPressedKeys)}");
         }
     }
 }

--- a/Assets/Scripts/RidersGame/StuntSystem/StuntSystem.cs
+++ b/Assets/Scripts/RidersGame/StuntSystem/StuntSystem.cs
@@ -21,13 +21,13 @@ namespace RidersRuntime.StuntSystem
             stuntDatabase.PopulateStunts();
         }
 
-        public void OnStuntRequestWithFrameData(List<FrameKeyData> frameData, StuntType stuntType)
+        public void OnStuntRequestTimed(List<TimedInput> timedInputs, StuntType stuntType)
         {
             // Handle the stunt request with frame data
             if (stuntType != StuntType.None)
             {
                 // Query the stunt database for the stunt
-                Stunt stunt = stuntDatabase.QueryStuntByFrames(stuntType, frameData);
+                Stunt stunt = stuntDatabase.QueryStuntByTime(stuntType, timedInputs);
                 if (stunt != Stunt.None)
                 {
                     // Execute the stunt
@@ -37,9 +37,14 @@ namespace RidersRuntime.StuntSystem
                 else
                 {
                     Debug.Log("No valid stunt found for the given frame data.");
-                    StuntPeripheralInputHandler.ShowSingleLineOutput(frameData);
                 }
             }
         }
+
+        public Stunt TryDetectStunt(List<TimedInput> timedInputs, StuntType stuntType)
+        {
+            return stuntType == StuntType.None ? Stunt.None : stuntDatabase.QueryStuntByTime(stuntType, timedInputs);
+        }
+
     }
 }

--- a/Assets/Scripts/RidersGame/StuntSystem/Types.cs
+++ b/Assets/Scripts/RidersGame/StuntSystem/Types.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 
 namespace RidersRuntime.StuntSystem
 {
-    public struct FrameKeyData
+    public struct TimedInput
     {
-        public int frameCount;
-        public List<string> inputs;
+        public float time;
+        public string key;
     }
 
     public enum StuntType
@@ -25,5 +25,7 @@ namespace RidersRuntime.StuntSystem
             { StuntButtonNamesShort.StuntB, StuntType.Grind },
             { StuntButtonNamesShort.StuntC, StuntType.Spin }
         };
+
+        public static float timeWindowMax = 0.5f;
     }
 }


### PR DESCRIPTION
https://jira.internal.teamriders.dev/browse/RDS-98

This commit does the following:
- Change inputs from frame comparisons (15 frames) to seconds (set to 0.5, can change to 0.25)
- Remove 60fps limit
- Optimise™ and simplify™ using the power of ChatGPT