### PR TITLE
Update ProjectSettings.asset

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -42,8 +42,8 @@ PlayerSettings:
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
-  defaultScreenWidth: 1600
-  defaultScreenHeight: 900
+  defaultScreenWidth: 1920
+  defaultScreenHeight: 1080
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0
@@ -71,7 +71,7 @@ PlayerSettings:
   androidRenderOutsideSafeArea: 1
   androidUseSwappy: 0
   androidBlitType: 0
-  androidResizeableActivity: 1
+  androidResizableActivity: 1
   androidDefaultWindowWidth: 1920
   androidDefaultWindowHeight: 1080
   androidMinimumWindowWidth: 400
@@ -92,9 +92,9 @@ PlayerSettings:
   usePlayerLog: 0
   dedicatedServerOptimizations: 1
   bakeCollisionMeshes: 0
-  forceSingleInstance: 0
+  forceSingleInstance: 1
   useFlipModelSwapchain: 1
-  resizableWindow: 0
+  resizableWindow: 1
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1
@@ -106,7 +106,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 2
+  fullscreenMode: 1
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
@@ -140,21 +140,20 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.1.0
-  preloadedAssets:
-  - {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  bundleVersion: 1.0.0
+  preloadedAssets:{fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1
   xboxOneDisableKinectGpuReservation: 1
   xboxOneEnable7thCore: 1
   vrSettings:
-    enable360StereoCapture: 0
+enable360StereoCapture: 0
   isWsaHolographicRemotingEnabled: 0
   enableFrameTimingStats: 0
   enableOpenGLProfilerGPURecorders: 1
-  allowHDRDisplaySupport: 0
-  useHDRDisplay: 0
+  allowHDRDisplaySupport: 1
+  useHDRDisplay: 1
   hdrBitDepth: 0
   m_ColorGamuts: 00000000
   targetPixelDensity: 30
@@ -164,18 +163,18 @@ PlayerSettings:
   androidMaxAspectRatio: 2.4
   androidMinAspectRatio: 1
   applicationIdentifier:
-    Android: com.UnityTechnologies.com.unity.template.urpblank
-    Standalone: com.Unity-Technologies.com.unity.template.urp-blank
-    iPhone: com.Unity-Technologies.com.unity.template.urp-blank
+Android: com.TeamRiders.ProjectRiders
+Standalone: com.TeamRiders.ProjectRiders
+iPhone: com.TeamRiders.ProjectRiders
   buildNumber:
-    Standalone: 0
-    VisionOS: 0
-    iPhone: 0
-    tvOS: 0
+Standalone: 0
+VisionOS: 0
+iPhone: 0
+tvOS: 0
   overrideDefaultApplicationIdentifier: 1
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 23
-  AndroidTargetSdkVersion: 0
+  AndroidMinSdkVersion: 24
+  AndroidTargetSdkVersion: 35
   AndroidPreferredInstallLocation: 1
   aotOptions: 
   stripEngineCode: 1
@@ -191,13 +190,13 @@ PlayerSettings:
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
   iOSSimulatorArchitecture: 0
-  iOSTargetOSVersionString: 13.0
+  iOSTargetOSVersionString: 15.0
   tvOSSdkVersion: 0
   tvOSSimulatorArchitecture: 0
   tvOSRequireExtendedGameController: 0
-  tvOSTargetOSVersionString: 13.0
+  tvOSTargetOSVersionString: 15.0
   VisionOSSdkVersion: 0
-  VisionOSTargetOSVersionString: 1.0
+  VisionOSTargetOSVersionString: 2.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
@@ -218,15 +217,15 @@ PlayerSettings:
   iOSLaunchScreenPortrait: {fileID: 0}
   iOSLaunchScreenLandscape: {fileID: 0}
   iOSLaunchScreenBackgroundColor:
-    serializedVersion: 2
-    rgba: 0
+serializedVersion: 2
+rgba: 0
   iOSLaunchScreenFillPct: 100
   iOSLaunchScreenSize: 100
   iOSLaunchScreeniPadType: 0
   iOSLaunchScreeniPadImage: {fileID: 0}
   iOSLaunchScreeniPadBackgroundColor:
-    serializedVersion: 2
-    rgba: 0
+serializedVersion: 2
+rgba: 0
   iOSLaunchScreeniPadFillPct: 100
   iOSLaunchScreeniPadSize: 100
   iOSLaunchScreenCustomStoryboardPath: 
@@ -279,9 +278,9 @@ PlayerSettings:
   androidUseLowAccuracyLocation: 0
   androidUseCustomKeystore: 0
   m_AndroidBanners:
-  - width: 320
-    height: 180
-    banner: {fileID: 0}
+width: 320
+height: 180
+banner: {fileID: 0}
   androidGamepadSupportLevel: 0
   AndroidMinifyRelease: 0
   AndroidMinifyDebug: 0
@@ -291,243 +290,243 @@ PlayerSettings:
   androidSymbolsSizeThreshold: 800
   m_BuildTargetIcons: []
   m_BuildTargetPlatformIcons:
-  - m_BuildTarget: iPhone
-    m_Icons:
-    - m_Textures: []
-      m_Width: 180
-      m_Height: 180
-      m_Kind: 0
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 120
-      m_Height: 120
-      m_Kind: 0
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 167
-      m_Height: 167
-      m_Kind: 0
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 152
-      m_Height: 152
-      m_Kind: 0
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 76
-      m_Height: 76
-      m_Kind: 0
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 120
-      m_Height: 120
-      m_Kind: 3
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 80
-      m_Height: 80
-      m_Kind: 3
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 80
-      m_Height: 80
-      m_Kind: 3
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 40
-      m_Height: 40
-      m_Kind: 3
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 87
-      m_Height: 87
-      m_Kind: 1
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 58
-      m_Height: 58
-      m_Kind: 1
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 29
-      m_Height: 29
-      m_Kind: 1
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 58
-      m_Height: 58
-      m_Kind: 1
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 29
-      m_Height: 29
-      m_Kind: 1
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 60
-      m_Height: 60
-      m_Kind: 2
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 40
-      m_Height: 40
-      m_Kind: 2
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 40
-      m_Height: 40
-      m_Kind: 2
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 20
-      m_Height: 20
-      m_Kind: 2
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 1024
-      m_Height: 1024
-      m_Kind: 4
-      m_SubKind: App Store
-  - m_BuildTarget: Android
-    m_Icons:
-    - m_Textures: []
-      m_Width: 432
-      m_Height: 432
-      m_Kind: 2
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 324
-      m_Height: 324
-      m_Kind: 2
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 216
-      m_Height: 216
-      m_Kind: 2
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 162
-      m_Height: 162
-      m_Kind: 2
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 108
-      m_Height: 108
-      m_Kind: 2
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 81
-      m_Height: 81
-      m_Kind: 2
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 192
-      m_Height: 192
-      m_Kind: 1
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 144
-      m_Height: 144
-      m_Kind: 1
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 96
-      m_Height: 96
-      m_Kind: 1
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 72
-      m_Height: 72
-      m_Kind: 1
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 48
-      m_Height: 48
-      m_Kind: 1
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 36
-      m_Height: 36
-      m_Kind: 1
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 192
-      m_Height: 192
-      m_Kind: 0
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 144
-      m_Height: 144
-      m_Kind: 0
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 96
-      m_Height: 96
-      m_Kind: 0
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 72
-      m_Height: 72
-      m_Kind: 0
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 48
-      m_Height: 48
-      m_Kind: 0
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 36
-      m_Height: 36
-      m_Kind: 0
-      m_SubKind: 
-  - m_BuildTarget: tvOS
-    m_Icons:
-    - m_Textures: []
-      m_Width: 1280
-      m_Height: 768
-      m_Kind: 0
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 800
-      m_Height: 480
-      m_Kind: 0
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 400
-      m_Height: 240
-      m_Kind: 0
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 4640
-      m_Height: 1440
-      m_Kind: 1
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 2320
-      m_Height: 720
-      m_Kind: 1
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 3840
-      m_Height: 1440
-      m_Kind: 1
-      m_SubKind: 
-    - m_Textures: []
-      m_Width: 1920
-      m_Height: 720
-      m_Kind: 1
-      m_SubKind: 
-  m_BuildTargetBatching: []
-  m_BuildTargetShaderSettings: []
-  m_BuildTargetGraphicsJobs: []
-  m_BuildTargetGraphicsJobMode: []
-  m_BuildTargetGraphicsAPIs:
-  - m_BuildTarget: iOSSupport
-    m_APIs: 10000000
-    m_Automatic: 1
-  - m_BuildTarget: AndroidPlayer
-    m_APIs: 150000000b000000
-    m_Automatic: 0
+m_BuildTarget: iPhone
+m_Icons:m_Textures: []
+m_Width: 180
+m_Height: 180
+m_Kind: 0
+m_SubKind: iPhone
+m_Textures: []
+m_Width: 120
+m_Height: 120
+m_Kind: 0
+m_SubKind: iPhone
+m_Textures: []
+m_Width: 167
+m_Height: 167
+m_Kind: 0
+m_SubKind: iPad
+m_Textures: []
+m_Width: 152
+m_Height: 152
+m_Kind: 0
+m_SubKind: iPad
+m_Textures: []
+m_Width: 76
+m_Height: 76
+m_Kind: 0
+m_SubKind: iPad
+m_Textures: []
+m_Width: 120
+m_Height: 120
+m_Kind: 3
+m_SubKind: iPhone
+m_Textures: []
+m_Width: 80
+m_Height: 80
+m_Kind: 3
+m_SubKind: iPhone
+m_Textures: []
+m_Width: 80
+m_Height: 80
+m_Kind: 3
+m_SubKind: iPad
+m_Textures: []
+m_Width: 40
+m_Height: 40
+m_Kind: 3
+m_SubKind: iPad
+m_Textures: []
+m_Width: 87
+m_Height: 87
+m_Kind: 1
+m_SubKind: iPhone
+m_Textures: []
+m_Width: 58
+m_Height: 58
+m_Kind: 1
+m_SubKind: iPhone
+m_Textures: []
+m_Width: 29
+m_Height: 29
+m_Kind: 1
+m_SubKind: iPhone
+m_Textures: []
+m_Width: 58
+m_Height: 58
+m_Kind: 1
+m_SubKind: iPad
+m_Textures: []
+m_Width: 29
+m_Height: 29
+m_Kind: 1
+m_SubKind: iPad
+m_Textures: []
+m_Width: 60
+m_Height: 60
+m_Kind: 2
+m_SubKind: iPhone
+m_Textures: []
+m_Width: 40
+m_Height: 40
+m_Kind: 2
+m_SubKind: iPhone
+m_Textures: []
+m_Width: 40
+m_Height: 40
+m_Kind: 2
+m_SubKind: iPad
+m_Textures: []
+m_Width: 20
+m_Height: 20
+m_Kind: 2
+m_SubKind: iPad
+m_Textures: []
+m_Width: 1024
+m_Height: 1024
+m_Kind: 4
+m_SubKind: App Store
+
+m_BuildTarget: Android
+m_Icons:m_Textures: []
+m_Width: 432
+m_Height: 432
+m_Kind: 2
+m_SubKind: 
+m_Textures: []
+m_Width: 324
+m_Height: 324
+m_Kind: 2
+m_SubKind: 
+m_Textures: []
+m_Width: 216
+m_Height: 216
+m_Kind: 2
+m_SubKind: 
+m_Textures: []
+m_Width: 162
+m_Height: 162
+m_Kind: 2
+m_SubKind: 
+m_Textures: []
+m_Width: 108
+m_Height: 108
+m_Kind: 2
+m_SubKind: 
+m_Textures: []
+m_Width: 81
+m_Height: 81
+m_Kind: 2
+m_SubKind: 
+m_Textures: []
+m_Width: 192
+m_Height: 192
+m_Kind: 1
+m_SubKind: 
+m_Textures: []
+m_Width: 144
+m_Height: 144
+m_Kind: 1
+m_SubKind: 
+m_Textures: []
+m_Width: 96
+m_Height: 96
+m_Kind: 1
+m_SubKind: 
+m_Textures: []
+m_Width: 72
+m_Height: 72
+m_Kind: 1
+m_SubKind: 
+m_Textures: []
+m_Width: 48
+m_Height: 48
+m_Kind: 1
+m_SubKind: 
+m_Textures: []
+m_Width: 36
+m_Height: 36
+m_Kind: 1
+m_SubKind: 
+m_Textures: []
+m_Width: 192
+m_Height: 192
+m_Kind: 0
+m_SubKind: 
+m_Textures: []
+m_Width: 144
+m_Height: 144
+m_Kind: 0
+m_SubKind: 
+m_Textures: []
+m_Width: 96
+m_Height: 96
+m_Kind: 0
+m_SubKind: 
+m_Textures: []
+m_Width: 72
+m_Height: 72
+m_Kind: 0
+m_SubKind: 
+m_Textures: []
+m_Width: 48
+m_Height: 48
+m_Kind: 0
+m_SubKind: 
+m_Textures: []
+m_Width: 36
+m_Height: 36
+m_Kind: 0
+m_SubKind:
+
+m_BuildTarget: tvOS
+m_Icons:m_Textures: []
+m_Width: 1280
+m_Height: 768
+m_Kind: 0
+m_SubKind: 
+m_Textures: []
+m_Width: 800
+m_Height: 480
+m_Kind: 0
+m_SubKind: 
+m_Textures: []
+m_Width: 400
+m_Height: 240
+m_Kind: 0
+m_SubKind: 
+m_Textures: []
+m_Width: 4640
+m_Height: 1440
+m_Kind: 1
+m_SubKind: 
+m_Textures: []
+m_Width: 2320
+m_Height: 720
+m_Kind: 1
+m_SubKind: 
+m_Textures: []
+m_Width: 3840
+m_Height: 1440
+m_Kind: 1
+m_SubKind: 
+m_Textures: []
+m_Width: 1920
+m_Height: 720
+m_Kind: 1
+m_SubKind: 
+m_BuildTargetBatching: []
+m_BuildTargetShaderSettings: []
+m_BuildTargetGraphicsJobs: []
+m_BuildTargetGraphicsJobMode: []
+m_BuildTargetGraphicsAPIs:
+
+m_BuildTarget: iOSSupport
+m_APIs: 10000000
+m_Automatic: 1
+m_BuildTarget: AndroidPlayer
+m_APIs: 150000000b000000
+m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16
   m_DefaultShaderChunkCount: 0
@@ -536,22 +535,22 @@ PlayerSettings:
   openGLRequireES32: 0
   m_TemplateCustomTags: {}
   mobileMTRendering:
-    Android: 1
-    iPhone: 1
-    tvOS: 1
+Android: 1
+iPhone: 1
+tvOS: 1
   m_BuildTargetGroupLightmapEncodingQuality:
-  - serializedVersion: 2
-    m_BuildTarget: Android
-    m_EncodingQuality: 1
+serializedVersion: 2
+m_BuildTarget: Android
+m_EncodingQuality: 1
   m_BuildTargetGroupLightmapSettings: []
   m_BuildTargetGroupLoadStoreDebugModeSettings: []
   m_BuildTargetNormalMapEncoding:
-  - m_BuildTarget: Android
-    m_Encoding: 1
+m_BuildTarget: Android
+m_Encoding: 1
   m_BuildTargetDefaultTextureCompressionFormat:
-  - serializedVersion: 3
-    m_BuildTarget: Android
-    m_Formats: 03000000
+serializedVersion: 3
+m_BuildTarget: Android
+m_Formats: 03000000
   playModeTestRunnerEnabled: 0
   runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1
@@ -821,7 +820,7 @@ PlayerSettings:
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend:
-    Android: 1
+Android: 1
   il2cppCompilerConfiguration: {}
   il2cppCodeGeneration: {}
   il2cppStacktraceInformation: {}
@@ -880,7 +879,7 @@ PlayerSettings:
   XboxOnePackageUpdateGranularity: 2
   XboxOneDescription: 
   XboxOneLanguage:
-  - enus
+enus
   XboxOneCapability: []
   XboxOneGameRating: {}
   XboxOneIsContentPackage: 0
@@ -896,16 +895,16 @@ PlayerSettings:
   vrEditorSettings: {}
   cloudServicesEnabled: {}
   luminIcon:
-    m_Name: 
-    m_ModelFolderPath: 
-    m_PortalFolderPath: 
+m_Name: 
+m_ModelFolderPath: 
+m_PortalFolderPath: 
   luminCert:
-    m_CertPath: 
-    m_SignPackage: 1
+m_CertPath: 
+m_SignPackage: 1
   luminIsChannelApp: 0
   luminVersion:
-    m_VersionCode: 1
-    m_VersionName: 
+m_VersionCode: 1
+m_VersionName: 
   hmiPlayerDataPath: 
   hmiForceSRGBBlit: 1
   embeddedLinuxEnableGamepadInput: 0
@@ -929,3 +928,6 @@ PlayerSettings:
   insecureHttpOption: 0
   androidVulkanDenyFilterList: []
   androidVulkanAllowFilterList: []
+
+13 web pages
+


### PR DESCRIPTION
For iOS, the current min version is 13.0, which is old; let's update to 15.0 for modern support.

AndroidTargetSdkVersion should be set to 35 to future-proof for Google Play's August 2025 requirements.

Setting forceSingleInstance to 1 will prevent multiple game instances from running.